### PR TITLE
feat: None to be encoded as an empty table cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ There are [8 possible data types in an Open Document Spreadsheet](https://docs.o
 | float       | float                         |
 | str         | string                        |
 | bytes       | string - base64 encoded       |
-| NoneType    | string - as #NA               |
+| NoneType    | no type - empty cell          |
 
 It is possible to change how each type is encoded by overriding the `encoders` parameter of the `stream_write_ods` function. See [stream-write-ods.py](https://github.com/uktrade/stream-write-ods/blob/main/stream_write_ods.py) for the default implementation.
 

--- a/stream_write_ods.py
+++ b/stream_write_ods.py
@@ -14,7 +14,7 @@ def stream_write_ods(sheets, encoders=(
     (type(0.0), ('float', 'office:value', str)),
     (type(''), ('string', None, str)),
     (type(b''), ('string', None, lambda v: b64encode(v).decode())),
-    (type(None), ('string', None, lambda _: '#NA')),
+    (type(None), (None, None, lambda _: None)),
 ), get_modified_at=lambda: datetime.now(), chunk_size=65536):
     encoders = dict(encoders)
     modified_at = get_modified_at()
@@ -58,12 +58,15 @@ def stream_write_ods(sheets, encoders=(
                     for value in row:
                         value_type, value_attr, encoder = encoders[type(value)]
                         encoded = encoder(value)
-                        yield f'<table:table-cell'
-                        yield f' office:value-type="{value_type}"'
-                        if value_attr is not None:
-                            yield f' {value_attr}={quoteattr(encoded)}'
-                        yield f'><text:p>{escape(encoded)}</text:p>'
-                        yield '</table:table-cell>'
+                        yield '<table:table-cell'
+                        if value_type is None:
+                            yield '/>'
+                        else:
+                            yield f' office:value-type="{value_type}"'
+                            if value_attr is not None:
+                                yield f' {value_attr}={quoteattr(encoded)}'
+                            yield f'><text:p>{escape(encoded)}</text:p>'
+                            yield '</table:table-cell>'
                     yield '</table:table-row>'
                 yield '</table:table>'
             yield '</office:spreadsheet>'

--- a/test_stream_write_ods.py
+++ b/test_stream_write_ods.py
@@ -50,7 +50,7 @@ def test_openable_with_pandas():
         [3.4,],
         [True,],
         ['QmluYXJ5IGRhdGE=',],
-        ['#NA',],
+        [None,],
         ['<![CDATA[',]
     ]
     assert sheet_2_cols == ['Column 1',]


### PR DESCRIPTION
This is probably closer to what a lot of users expect. Pandas converts it to None, so it doesn't appear to be a loss of information.