### PR TITLE
Add ZIP_64 as an optional method and additional tests

### DIFF
--- a/test_stream_write_ods.py
+++ b/test_stream_write_ods.py
@@ -56,10 +56,48 @@ def test_openable_with_pandas():
     assert sheet_2_cols == ['Column 1',]
 
 
+def test_openable_with_pandas_zip_64():
+    with NamedTemporaryFile() as f:
+        f.write(b''.join(stream_write_ods(get_sheets(), use_zip_64=True)))
+        f.flush()
+        sheet_1 = read_ods(f.name, 'Sheet 1 <&> \'""')
+        sheet_1_rows = sheet_1.values.tolist()
+        sheet_1_cols =  sheet_1.columns.tolist()
+        sheet_2 = read_ods(f.name, "Sheet 2")
+        sheet_2_rows = sheet_2.values.tolist()
+        sheet_2_cols =  sheet_2.columns.tolist()
+
+    assert sheet_1_rows == [
+        ['Row 1 Column 1 <&>', 'Row 1 Column 2 <&>'],
+        ['Row 2 Column 1 <&>', 'Row 2 Column 2 <&>'],
+    ]
+    assert sheet_1_cols == ['Column 1 <&>', 'Column 2 <&>']
+    assert sheet_2_rows == [
+        ['Row 1 Column 1',],
+        ['2021-01-01T10:01:04',],
+        ['2021-01-01',],
+        [2.0,],
+        [3.4,],
+        [True,],
+        ['QmluYXJ5IGRhdGE=',],
+        [None,],
+        ['<![CDATA[',]
+    ]
+    assert sheet_2_cols == ['Column 1',]
+
+
 def test_has_correct_magic_values():
     data = b''.join(stream_write_ods(get_sheets()))
 
     # Per http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part3.odt
+    assert data[0:2] == b'PK'
+    assert data[30:38] == b'mimetype'
+    assert data[38:84] == b'application/vnd.oasis.opendocument.spreadsheet'
+
+
+def test_has_correct_magic_values_zip_64():
+    data = b''.join(stream_write_ods(get_sheets(), use_zip_64=True))
+
     assert data[0:2] == b'PK'
     assert data[30:38] == b'mimetype'
     assert data[38:84] == b'application/vnd.oasis.opendocument.spreadsheet'


### PR DESCRIPTION
Adding ZIP_64 as an optional method for compressing files, essential when the data is bigger than 4GB. 
Zip64 ODS files can now be read in LibreOffice.